### PR TITLE
Multiple prescribed force timeseries files for BStC

### DIFF
--- a/modules/servodyn/src/StrucCtrl_Registry.txt
+++ b/modules/servodyn/src/StrucCtrl_Registry.txt
@@ -9,6 +9,8 @@
 ###################################################################################################################################
 include	Registry_NWTC_Library.txt
 
+typedef	StrucCtrl/StC	StC_PrescrFrcTseries	ReKi			data	{:}{:}	-	-	"StC prescribed force time-series info"	"(s,N,N-m)"
+
 # ..... Input File data .......................................................................................................
 typedef StrucCtrl/StC StC_InputFile CHARACTER(1024) StCFileName - - - "Name of the input file; remove if there is no file" -
 typedef	^		^				LOGICAL			Echo	-	-	-	"Echo input file to echo file"	-
@@ -73,8 +75,8 @@ typedef	^		^				IntKi			NKInpSt	-	-	-	"Number of input spring force rows in tabl
 typedef	^		^				CHARACTER(1024)			StC_F_TBL_FILE	-	-	-	"user-defined spring table filename"	-
 typedef	^		^				ReKi			F_TBL		{:}{:}	-	-	"user-defined spring force"	"N"
 typedef	^		^				IntKi			PrescribedForcesCoordSys	-	-	-	"Prescribed forces coordinate system {0: global; 1: local}"	-
-typedef	^		^				CHARACTER(1024)	PrescribedForcesFile	-	-	-	"Prescribed force time-series filename"	-
-typedef	^		^				ReKi			StC_PrescribedForce	{:}{:}	-	-	"StC prescribed force time-series info"	"(s,N,N-m)"
+typedef	^		^				CHARACTER(1024)	PrescribedForcesFile	:	-	-	"Prescribed force time-series filename"	-
+typedef	^		^				StC_PrescrFrcTseries			StC_PrescribedForce	{:}	-	-	"StC prescribed force time-series info"	"(s,N,N-m)"
 typedef	^		^				IntKi			StC_CChan	{:}	-	-	"StC control chan to use -- one per instance"	-
 # ..... Initialization data .......................................................................................................
 # Define inputs that the initialization routine may need here:
@@ -194,7 +196,7 @@ typedef	^		^				LOGICAL			Use_F_TBL	-	-	-	"use spring force from user-defined ta
 typedef	^		^				ReKi			F_TBL	{:}{:} - -	"user-defined spring force"	"N"
 typedef	^	ParameterType	IntKi	NumMeshPts	-	-	-	"Number of mesh points"	-
 typedef	^		^				IntKi			PrescribedForcesCoordSys	-	-	-	"Prescribed forces coordinate system {0: global; 1: local}"	-
-typedef	^		^				ReKi			StC_PrescribedForce	{:}{:}	-	-	"StC prescribed force time-series info"	"(s,N,N-m)"
+typedef	^		^				StC_PrescrFrcTseries			StC_PrescribedForce	{:}	-	-	"StC prescribed force time-series info"	"(s,N,N-m)"
 typedef	^		^				IntKi			StC_CChan	{:}	-	-	"StC control chan to use"	-
 # ..... Inputs ....................................................................................................................
 # Define inputs that are contained on the mesh here:


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

Pulling in @andrew-platt's implementation of multiple time series for blades.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

StC

**Additional supporting information**
<!-- Add any other context about the problem here. -->

Ran a simple check here:

`equalForces` applies 100N at blade tip in +x for all three blades.
'unequal forces` applies 100N, 200N, and 300N at blade tip in +x to blade 1,2,3 respectively.

![image](https://github.com/user-attachments/assets/4234d18e-92e5-4eaa-bb9d-ca0f7664f208)

The flap wise tip displacement shows increases corresponding to the changes in force

![image](https://github.com/user-attachments/assets/903740fb-60c7-4661-8785-e4bdc8d9b340)

![image](https://github.com/user-attachments/assets/fbb6610f-fd9d-458a-8c71-abd7197a5f06)


**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
